### PR TITLE
irgen: Create functions instead of global variables for builtin hash …

### DIFF
--- a/irgen/typemap.go
+++ b/irgen/typemap.go
@@ -151,9 +151,9 @@ func NewTypeMap(pkg *ssa.Package, llvmtm *llvmTypeMap, module llvm.Module, r *ru
 		hashDescriptorName := hashFnName + "_descriptor"
 		equalFnName := "__go_type_equal_" + typeAlgs.Name
 		equalDescriptorName := equalFnName + "_descriptor"
-		typeAlgs.hash = llvm.AddGlobal(tm.module, tm.hashFnType, hashFnName)
+		typeAlgs.hash = llvm.AddFunction(tm.module, hashFnName, tm.hashFnType)
 		typeAlgs.hashDescriptor = llvm.AddGlobal(tm.module, tm.funcValType, hashDescriptorName)
-		typeAlgs.equal = llvm.AddGlobal(tm.module, tm.equalFnType, equalFnName)
+		typeAlgs.equal = llvm.AddFunction(tm.module, equalFnName, tm.equalFnType)
 		typeAlgs.equalDescriptor = llvm.AddGlobal(tm.module, tm.funcValType, equalDescriptorName)
 	}
 


### PR DESCRIPTION
…and equal algorithms.

These are in fact functions, and have function type, so it is invalid
to represent them using global variables.

git-svn-id: https://llvm.org/svn/llvm-project/llgo/trunk@304689 91177308-0d34-0410-b5e6-96231b3b80d8